### PR TITLE
Use nice isoformat for dateString

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+python-dateutil
+

--- a/uploader.py
+++ b/uploader.py
@@ -1,25 +1,31 @@
 import argparse
 import time
+from datetime import datetime
+from dateutil.tz import gettz
+from dateutil.parser import parse
 import calendar
 import requests
+import json
 import hashlib
 
 
 def isANumber(string):
-	try:
-		i = int(string)
-	except (ValueError, TypeError):
-		try:
-			i = float(string)
-		except (ValueError, TypeError):
-			return False
+  try:
+    i = int(string)
+  except (ValueError, TypeError):
+    try:
+      i = float(string)
+    except (ValueError, TypeError):
+      return False
 
-	return True
+  return True
 
 parser = argparse.ArgumentParser(description='Process some integers.')
 parser.add_argument('--api_secret', help="API-SECRET for uploading", required=True)
 parser.add_argument('--base_url', help="Base URL of site", required=True)
+parser.add_argument('--noninteractive', default=False, action='store_true')
 parser.add_argument('--debug', action='store_true')
+parser.add_argument('--timezone', default=gettz( ), type=gettz, help="Timezone to use.")
 parser.add_argument('--mmol', help="Data entered as mmol", action='store_true')
 #parser.add_argument('--data_type', choices=['sgv', 'cal'],default="sgv")
 args = parser.parse_args()
@@ -32,48 +38,46 @@ print "Enter 'q' to quit"
 
 prompt = ""
 if args.mmol:
-	prompt = "Enter current BG (mmol/L): "
+  prompt = "Enter current BG (mmol/L): "
 else:
-	prompt = "Enter current BG (mg/dL): "
+  prompt = "Enter current BG (mg/dL): "
 
 while (True):
 
-	bg = raw_input(prompt)
+  bg = raw_input(prompt)
 
-	if (bg == "q"):
-		break
+  if (bg == "q"):
+    break
 
-	print("Uploading BG " + bg)
+  print("Uploading BG " + bg)
 
-	if ( isANumber(bg) == False):
-		print "Invalid value entered: %s" % bg
-		continue
+  if ( isANumber(bg) == False):
+    print "Invalid value entered: %s" % bg
+    continue
 
-	if (args.mmol):
-		bg = float(bg)
-		bg *= 18.018018
-		bg = int(bg)
-		
-	current_time = time.time()
-	time_struct = time.localtime(current_time)
+  if (args.mmol):
+    bg = float(bg)
+    bg *= 18.018018
+    bg = int(bg)
+    
+  current_time = time.time( )
+  now = datetime.fromtimestamp(current_time).replace(tzinfo=args.timezone)
 
-	payload = """[{\"type\": \"sgv\",
-	\"sgv\": %s,
-	\"date\": %d,
-	\"dateString\": \"%s\"
-	}]
-	""" % (bg, current_time * 1000, time.asctime(time_struct))
+  payload = dict(type='sgv', sgv=bg, date=int(current_time * 1000), dateString=now.isoformat( ))
 
-	if args.debug:
-		print "%s\n" % payload
+  if args.debug:
+    print "%s\n" % payload
 
-	headers = {'API-SECRET' : hashed_secret,
-		   'Content-Type': "application/json",
-		   'Accept': 'application/json'}
-	r = requests.post(url, headers=headers, data=payload)
-	
-	if (r.status_code == 200):
-		print "Uploaded successfully"
-	else:
-		print "%d" % r.status_code 
-		print r.text
+  headers = {'API-SECRET' : hashed_secret,
+       'Content-Type': "application/json",
+       'Accept': 'application/json'}
+  r = requests.post(url, headers=headers, data=json.dumps(payload))
+  
+  if (r.status_code == 200):
+    print "Uploaded successfully"
+  else:
+    print "%d" % r.status_code 
+    print r.text
+
+  if args.noninteractive:
+    break


### PR DESCRIPTION
Using iso8601 format allows the REST api to sort/filter against times better,
allowing modal day queries.

Also introduce some other python niceties, including ability to switch
timezones.

To install, do `pip install -r requirements.txt` or
`easy_install -ZU python-dateutil`

See
https://github.com/bewest/decoding-carelink/blob/master/bin/mm-latest.py#L164-L165
for more details.
